### PR TITLE
GT-0 update form layout

### DIFF
--- a/src/cockpit/components/CEditItem.vue
+++ b/src/cockpit/components/CEditItem.vue
@@ -58,7 +58,7 @@ export default {
 }
 
 .edit_item_large {
-  height: 75px;
+  min-height: 75px;
 }
 
 .edit_item_small {

--- a/src/cockpit/components/CEditTrip.vue
+++ b/src/cockpit/components/CEditTrip.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   .edit_trip
-    form
+    form.edit_form
       CEditItem(
         :className="'editTripName'"
         :label="'Name'"
@@ -230,6 +230,10 @@ export default Vue.extend({
 
 <style lang="scss">
 @import "../shared/lib";
+.edit_form {
+  display: flex;
+  flex-direction: column;
+}
 
 .confirmationButtons {
   margin-top: 20px;
@@ -249,7 +253,6 @@ export default Vue.extend({
 
 .editTripPrivacy .editInput {
   margin-top: 10px;
-  width: 40px;
 }
 
 .editTripPrivacy {


### PR DESCRIPTION
When you increase the height of a textarea, the form layout get push in a funny way. 

With this fix, user can increase the height of textarea without breaking the UI.