### PR TITLE
Update wings to use latest version and added formatting as part of build process

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -30,8 +30,17 @@ cmd = run "//:lint_all"
 ImportPath = github.com/binhonglee/GlobeTrotte
 
 [Buildconfig]
+
+# npm
 npm-tool = "pnpm"
 npx-tool = "pnpx"
 typescript-tool = "esbuild"
 # Still haven't figure out how to do Vue 3 component testing
 disable-vue-component-tests = True
+
+# wings
+wings-config-rule = "//:wings_config"
+wings-formatter-go = "gofmt -s -w $FILE"
+
+# eslint is really slow :( just ignoring them for now.
+# wings-formatter-ts = "pnpx eslint $FILE --fix"

--- a/.plzconfig
+++ b/.plzconfig
@@ -39,6 +39,7 @@ typescript-tool = "esbuild"
 disable-vue-component-tests = True
 
 # wings
+wings-tool = "//:wings_binary"
 wings-config-rule = "//:wings_config"
 wings-formatter-go = "gofmt -s -w $FILE"
 

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 subinclude("//build_defs/npm")
 subinclude("//build_defs/npm:ava")
 subinclude("//build_defs/npm:jest")
+subinclude("//build_defs/sh")
 
 filegroup(
   name = "babel_config",
@@ -63,6 +64,15 @@ filegroup(
   name = "wings_config",
   srcs = ["wings.json"],
   visibility = ["//src/wings/..."],
+)
+
+sh_exec(
+  name = "wings_binary",
+  # TODO: update the wings script to allow downloading the right binary to specified location
+  cmd = "curl -s https://wings.sh/install.sh | sh && cp $HOME/.wings/bin/wings ./",
+  outs = ["wings"],
+  set_home_path = True,
+  visibility = ["PUBLIC"],
 )
 
 filegroup(

--- a/build_defs/sh/BUILD
+++ b/build_defs/sh/BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["PUBLIC"])
+
+filegroup(
+  name = "sh",
+  srcs = ["sh.build_defs"],
+  deps = ["//build_defs/gen"],
+)

--- a/build_defs/sh/sh.build_defs
+++ b/build_defs/sh/sh.build_defs
@@ -1,0 +1,14 @@
+subinclude("//build_defs/gen")
+
+def sh_exec(name:str, cmd:str, outs:list, set_home_path:bool=False, deps:list=[], tools:dict|list=[], visibility:list=[]):
+  if set_home_path:
+    cmd = _home_path() + " && " + cmd
+
+  return build_rule(
+    name = name,
+    cmd = cmd,
+    outs = outs,
+    tools = tools,
+    deps = deps,
+    visibility = visibility,
+  )

--- a/build_defs/wings/wings.build_defs
+++ b/build_defs/wings/wings.build_defs
@@ -1,23 +1,36 @@
 subinclude("//build_defs/gen")
 
-def wings_lib(name:str, src:str, outs:dict, config:str="", test_only=False, visibility:list=None, deps:list=[]):
+def wings_lib(
+  name:str, src:str, outs:dict, test_only=False, visibility:list=None, deps:list=[],
+):
   all_out_files = []
 
-  filegroup(
+  src_file = filegroup(
     name = f"_{name}#wings",
     srcs = [src],
+    requires = ["wings"],
     visibility = visibility,
-    binary = False,
+    exported_deps = deps,
     test_only = test_only,
   )
 
+  config = []
+  if CONFIG.WINGS_CONFIG_RULE != "":
+    config = [CONFIG.WINGS_CONFIG_RULE]
+
   cmd = " && ".join([
     _home_path(),
-    "FILES=$(find * -name '*.wings')",
-    "$TOOL -c:" + config + " $FILES",
+    "$TOOL -c:" + CONFIG.WINGS_CONFIG_FILENAME + " $SRC",
   ])
 
   for i in outs.keys():
+    filetype = (outs[i].split("."))[-1]
+    if CONFIG["WINGS_FORMATTER_" + upper(filetype)] != "":
+      cmd += " && " + " && ".join([
+        _go_to_top_level(),
+        "FILE=\"" + i + "/" + outs[i] + "\"",
+        CONFIG["WINGS_FORMATTER_" + upper(filetype)],
+      ])
     all_out_files.append(i + "/" + outs[i])
 
   gen_files = build_rule(
@@ -26,8 +39,7 @@ def wings_lib(name:str, src:str, outs:dict, config:str="", test_only=False, visi
     tools = [CONFIG.WINGS_TOOL],
     cmd = cmd,
     outs = all_out_files,
-    deps = deps + [":" + f"_{name}#wings"],
-    needs_transitive_deps = True,
+    deps = [src_file] + config,
     test_only = test_only,
     binary = False,
     visibility = visibility,
@@ -38,10 +50,12 @@ def wings_lib(name:str, src:str, outs:dict, config:str="", test_only=False, visi
   for i in outs.keys():
     filetype = (outs[i].split("."))[-1]
     lang_name = f"_{name}#{filetype}"
+    cmd = "mv $PKG_DIR/" + i + "/" + outs[i] + " ./"
+
     build_rule(
       name = lang_name,
       srcs = [gen_files],
-      cmd = "mv $PKG_DIR/" + i + "/" + outs[i] + " ./",
+      cmd = cmd,
       outs = [outs[i]],
       visibility = visibility,
       binary = False,
@@ -50,11 +64,12 @@ def wings_lib(name:str, src:str, outs:dict, config:str="", test_only=False, visi
     )
 
     provides[filetype] = ":" + lang_name
+  provides["wings"] = src_file
 
   return filegroup(
     name = name,
-    srcs = [gen_files],
-    deps = deps + provides.values() + [":" + f"_{name}#wings"],
+    srcs = [gen_files, src_file],
+    deps = deps + provides.values(),
     needs_transitive_deps = True,
     test_only = test_only,
     provides = provides,
@@ -63,3 +78,7 @@ def wings_lib(name:str, src:str, outs:dict, config:str="", test_only=False, visi
   )
 
 CONFIG.setdefault("WINGS_TOOL", "wings")
+CONFIG.setdefault("WINGS_CONFIG_RULE", "")
+CONFIG.setdefault("WINGS_CONFIG_FILENAME", "wings.json")
+CONFIG.setdefault("WINGS_FORMATTER_GO", "")
+CONFIG.setdefault("WINGS_FORMATTER_TS", "")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -226,17 +226,7 @@ installWings() {
     return
   fi
   
-  case $OS in
-    "Darwin")
-      Download_OS="macosx"
-      ;;
-    "Linux")
-      Download_OS="linux"
-      ;;
-  esac
-
-  sudo curl -L https://github.com/binhonglee/wings/releases/download/v0.0.6-alpha/wings_64bit_$Download_OS -o /usr/local/bin/wings
-  sudo chmod +x /usr/local/bin/wings
+  curl -s https://wings.sh/install.sh | sh
 }
 
 if ! echo "$SUPPORTED_OS" | grep -w "$OS" > /dev/null; then

--- a/src/wings/enum/BUILD
+++ b/src/wings/enum/BUILD
@@ -11,28 +11,20 @@ filegroup(
 
 wings_lib(
   name = "city",
-  config = "wings.json",
   src = "city.wings",
   outs = {
     "src/cockpit/wings": "City.ts",
     "src/turbine/wings": "city.go",
   },
-  deps = [
-    "//:wings_config",
-  ],
   visibility = ["PUBLIC"],
 )
 
 wings_lib(
   name = "access_level",
-  config = "wings.json",
   src = "access_level.wings",
   outs = {
     "src/cockpit/wings": "AccessLevel.ts",
     "src/turbine/wings": "accesslevel.go",
   },
-  deps = [
-    "//:wings_config",
-  ],
   visibility = ["PUBLIC"],
 )

--- a/src/wings/struct/BUILD
+++ b/src/wings/struct/BUILD
@@ -20,54 +20,42 @@ filegroup(
 
 wings_lib(
   name = "day",
-  config = "wings.json",
   src = "day.wings",
   outs = {
     "src/cockpit/wings": "Day.ts",
     "src/turbine/wings": "day.go",
   },
   deps = [
-    "//:wings_config",
     ":place",
   ],
 )
 
 wings_lib(
   name = "new_user",
-  config = "wings.json",
   src = "new_user.wings",
   outs = {
     "src/cockpit/wings": "NewUser.ts",
     "src/turbine/wings": "newuser.go",
   },
-  deps = [
-    "//:wings_config",
-  ],
 )
 
 wings_lib(
   name = "place",
-  config = "wings.json",
   src = "place.wings",
   outs = {
     "src/cockpit/wings": "Place.ts",
     "src/turbine/wings": "place.go",
   },
-  deps = [
-    "//:wings_config",
-  ],
 )
 
 wings_lib(
   name = "trip",
-  config = "wings.json",
   src = "trip.wings",
   outs = {
     "src/cockpit/wings": "Trip.ts",
     "src/turbine/wings": "trip.go",
   },
   deps = [
-    "//:wings_config",
     ":day",
     ":user_access_level",
     "//src/wings/enum:city",
@@ -76,14 +64,12 @@ wings_lib(
 
 wings_lib(
   name = "trip_basic",
-  config = "wings.json",
   src = "trip_basic.wings",
   outs = {
     "src/cockpit/wings": "TripBasic.ts",
     "src/turbine/wings": "tripbasic.go",
   },
   deps = [
-    "//:wings_config",
     ":day",
     ":user_access_level",
     "//src/wings/enum:city",
@@ -92,14 +78,12 @@ wings_lib(
 
 wings_lib(
   name = "trip_obj",
-  config = "wings.json",
   src = "trip_obj.wings",
   outs = {
     "src/cockpit/wings": "TripObj.ts",
     "src/turbine/trip": "tripobj.go",
   },
   deps = [
-    "//:wings_config",
     ":user_basic",
     ":trip_basic",
     ":user_access_level",
@@ -108,38 +92,30 @@ wings_lib(
 
 wings_lib(
   name = "user",
-  config = "wings.json",
   src = "user.wings",
   outs = {
     "src/cockpit/wings": "User.ts",
     "src/turbine/wings": "user.go",
   },
-  deps = [
-    "//:wings_config",
-  ],
 )
 
 wings_lib(
   name = "user_basic",
-  config = "wings.json",
   src = "user_basic.wings",
   outs = {
     "src/cockpit/wings": "UserBasic.ts",
     "src/turbine/wings": "userbasic.go",
   },
-  deps = ["//:wings_config"],
 )
 
 wings_lib(
   name = "user_obj",
-  config = "wings.json",
   src = "user_obj.wings",
   outs = {
     "src/cockpit/wings": "UserObj.ts",
     "src/turbine/user": "userobj.go",
   },
   deps = [
-    "//:wings_config",
     ":user_basic",
     ":trip_basic",
   ],
@@ -147,40 +123,30 @@ wings_lib(
 
 wings_lib(
   name = "user_access_level",
-  config = "wings.json",
   src = "user_access_level.wings",
   outs = {
     "src/cockpit/wings": "UserAccessLevel.ts",
     "src/turbine/wings": "useraccesslevel.go",
   },
   deps = [
-    "//:wings_config",
     "//src/wings/enum:access_level",
   ],
 )
 
 wings_lib(
   name = "email_obj",
-  config = "wings.json",
   src = "email_obj.wings",
   outs = {
     "src/cockpit/wings": "EmailObj.ts",
     "src/turbine/email": "emailobj.go",
   },
-  deps = [
-    "//:wings_config",
-  ],
 )
 
 wings_lib(
   name = "reset_password",
-  config = "wings.json",
   src = "reset_password.wings",
   outs = {
     "src/cockpit/wings": "ResetPassword.ts",
     "src/turbine/access": "resetpassword.go",
   },
-  deps = [
-    "//:wings_config",
-  ],
 )


### PR DESCRIPTION
Currently when wings generate files on build, they are left as is causing `git status` to leave a lot of trail before `plz lint` is called. This patch includes formatter as part of the build process thus no longer need to manually do `plz lint` every time wings re-generate existing files. On top of that, the wings config dependency is also consolidated into a single line in `.plzconfig` as part of wings config instead of having to repeat it for every single `wings_lib()` rule.